### PR TITLE
Genereate valid SI-UBL when using DueDate

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -480,10 +480,17 @@ class Invoice implements XmlSerializable
 
         $writer->write([
             Schema::CBC . 'IssueDate' => $this->issueDate->format('Y-m-d'),
-            [
-                'name' => Schema::CBC . 'InvoiceTypeCode',
-                'value' => $this->invoiceTypeCode
-            ]
+        ]);
+
+        // To be valid, duedate must sit between IssueDate and InvoiceTypeCode
+        if ($this->dueDate !== null) {
+            $writer->write([
+                Schema::CBC . 'DueDate' => $this->dueDate->format('Y-m-d')
+            ]);
+        }
+
+        $writer->write([
+            Schema::CBC . 'InvoiceTypeCode' => $this->invoiceTypeCode,
         ]);
 
         if ($this->taxPointDate !== null) {


### PR DESCRIPTION
When DueDate is not set between IssueDate and InvoiceTypeCode validation will fail. This PR will fix this.