### PR TITLE
DocumenType should not be specified for UBL be

### DIFF
--- a/src/AdditionalDocumentReference.php
+++ b/src/AdditionalDocumentReference.php
@@ -73,10 +73,12 @@ class AdditionalDocumentReference implements XmlSerializable
      */
     public function xmlSerialize(Writer $writer)
     {
-        $writer->write([
-            Schema::CBC . 'ID' => $this->id,
-            Schema::CBC . 'DocumentType' => $this->documentType,
-            Schema::CAC . 'Attachment' => $this->attachment,
-        ]);
+        $writer->write([ Schema::CBC .'ID' => $this->id ]);
+        if ($this->documentType !== null) {
+            $writer->write([
+                Schema::CAC . 'DocumentType' => $this->documentType
+            ]);
+        }
+        $writer->write([ Schema::CAC .'Attachment' => $this->attachment ]);
     }
 }


### PR DESCRIPTION
When DocumentType is not specified, the xml writer will still write it to the xml as an empty value. With this PR you still can use DocumentType but when you don't want it (to comply with UBL 2.1) it will write the correct XML.